### PR TITLE
In order to make CI builds faster, the image now contains an initiali…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,13 @@ COPY ./scripts/*.sh ${ORACLE_BASE}/scripts/
 
 RUN chmod a+x ${ORACLE_BASE}/scripts/*.sh 
 
+# During image build, start Oracle once in order to pregenerate the oradata directory into the image.
+RUN ${ORACLE_BASE}/scripts/${RUN_FILE} exit
+
 # 1521: Oracle listener
 # 5500: Oracle Enterprise Manager (EM) Express listener.
 # 4444: Oracle ready indicator
 EXPOSE 1521 5500 4444
-
-VOLUME [ "${ORACLE_BASE}/oradata" ]
 
 HEALTHCHECK --interval=1m --start-period=2m --retries=10 \
   CMD "$ORACLE_BASE/scripts/$CHECK_DB_FILE"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 This is a fork from https://github.com/fuzziebrain/docker-oracle-xe with the following modifications:
 
+- Image contains the oradata directory, so containers will start up faster.
 - Supports user/schema creation via environment variables:
    - ORACLE_USER   
    - ORACLE_PASSWORD
@@ -69,7 +70,7 @@ docker build -t oracle-xe:18c .
 
 ## Run Container
 
-_Note first time will take a a while to run for as the `oracle-xe configure` script needs to complete_
+_Note first time will take a while to run for as the `oracle-xe configure` script needs to complete_
 
 ```bash
 docker run -d \

--- a/scripts/runOracle.sh
+++ b/scripts/runOracle.sh
@@ -156,6 +156,13 @@ echo "====================="
 echo "== Oracle ready ====="
 echo "====================="
 
+# When building the image, we want to exit at this point.
+if [[ "$1" = "exit" ]]
+then
+    echo "Exiting as requested"
+    exit 0
+fi
+
 # Open a port to indicate the database is ready.
 # Keep listening so container does not exit.
 nc -k -l 4444 > /dev/null


### PR DESCRIPTION
In order to make CI builds faster, the image now contains an initialized oradata directory. And it no longer is a mounted volume.